### PR TITLE
Fix duplicate ID error.

### DIFF
--- a/_sources/Input_and_Output/InputandOutput.rst
+++ b/_sources/Input_and_Output/InputandOutput.rst
@@ -80,7 +80,7 @@ To close the file for ``out_stream``, we use its ``close()`` function, which als
 
 Answer the question below concerning the use of the ``fstream`` library:
 
-.. mchoice:: stream_library
+.. mchoice:: stream_library_1
    :answer_a: Yes, ofstream is required to edit the file.
    :answer_b: Yes, using ifstream will wipe the file clean without using ofstream first.
    :answer_c: No, using ofstream on a file that already has information on it will clear the entire file.
@@ -284,7 +284,7 @@ Check Yourself
 ~~~~~~~~~~~~~~
 
 
-.. mchoice:: stream_library
+.. mchoice:: stream_library_2
    :multiple_answers:
    :answer_a: fstream
    :answer_b: ifstream

--- a/pavement.py
+++ b/pavement.py
@@ -30,7 +30,7 @@ if not master_url:
 
 master_app = 'runestone'
 serving_dir = "./build/cpp4python"
-dynamic_pages = True
+dynamic_pages = False
 if dynamic_pages:
     dest = './published'
 else:

--- a/pavement.py
+++ b/pavement.py
@@ -30,7 +30,7 @@ if not master_url:
 
 master_app = 'runestone'
 serving_dir = "./build/cpp4python"
-dynamic_pages = False
+dynamic_pages = True
 if dynamic_pages:
     dest = './published'
 else:


### PR DESCRIPTION
Changed the ID's for two multiple choice questions that had the same label in Input_and_Output/Input_and_Output.rst.